### PR TITLE
added error handling for mongodb connection failures 

### DIFF
--- a/lib/stores/mongodb.js
+++ b/lib/stores/mongodb.js
@@ -155,7 +155,7 @@ module.exports = function (options, callback) {
     query = query || {};
     this.collection.count(query, callback);
   };
-
+  connection.on('error', function(e){throw Error('Mongo DB Connection failed '+ e); })
   connection.open(function (err, db) {
     db.collection(options.collection || 'translations', function (err, collection) {
       mongoStore.collection = collection;


### PR DESCRIPTION
Hi Masylum,

its always me so don't worry;)
This is a one liner fix for an annoying problem, when handling database connection to mongodb (note I haven't tested this with the other stores):
Dialect failes silently if there is no mongodb server running, so I throw an exception here, that can be caught somewhere else.
Otherwise if there is no connection you get output like
     ECONNREFUSED, Connection refused
with no indication at all of where the problem was. At least now it prints a stacktrace indicating a MongoDB failure.

Best regards

Gregor
