### PR TITLE
Authentication for MongoDB Store

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,8 @@ Dialect is a painless nodejs module to manage your translations.
   * `host`: _127.0.0.1_
   * `port`: _27017_
   * `collection`: _translations_
+  * `username` (optional)
+  * `password` (optional)
 * `sqlite`
   * `database`: _dialect.db_
   * `table`: _dialect_

--- a/lib/stores/mongodb.js
+++ b/lib/stores/mongodb.js
@@ -58,7 +58,12 @@ module.exports = function (options) {
     function collectionSetup() {
       STORE.db.collection(options.collection || 'translations', function (err, collection) {
           if (collection) {
-            connect(err, collection);
+            collection.ensureIndex(
+                {original: 1, locale: 1, translation: 1},
+                {unique: true},
+                function (err) {
+                  connect(err, collection);
+                });
           } else {
             STORE.db.createCollection(options.collection || 'translations', function (err, collection) {
               connect(err, collection);

--- a/lib/stores/mongodb.js
+++ b/lib/stores/mongodb.js
@@ -55,20 +55,34 @@ module.exports = function (options) {
       callback(err, collection);
     }
 
+    function collectionSetup() {
+      STORE.db.collection(options.collection || 'translations', function (err, collection) {
+          if (collection) {
+            connect(err, collection);
+          } else {
+            STORE.db.createCollection(options.collection || 'translations', function (err, collection) {
+              connect(err, collection);
+            });
+          }
+      });
+    }
+
     if (!_is_connected) {
       STORE.db.open(function (err, db) {
         if (err) {
           callback(err, null);
         } else {
-          STORE.db.collection(options.collection || 'translations', function (err, collection) {
-            if (collection) {
-              connect(err, collection);
-            } else {
-              STORE.db.createCollection(options.collection || 'translations', function (err, collection) {
-                connect(err, collection);
-              });
-            }
-          });
+          if (options.username && options.password) {
+            db.authenticate(options.username, options.password, function (err) {
+              if (err) {
+                callback(err, null);
+              } else {
+                collectionSetup();
+              }
+            });
+          } else {
+            collectionSetup();
+          }
         }
       });
     }


### PR DESCRIPTION
MongoDB supports protecting databases with a username and a password. This patch enables dialect's mongodb store to use such databases.

Tested locally and with a database on mongohq.com.
