### PR TITLE
Allow specifying the locale on 'get'

### DIFF
--- a/examples/hello_world.js
+++ b/examples/hello_world.js
@@ -1,20 +1,26 @@
 var dialect = require('..').dialect({
-      locales: ['es', 'en'],
+      locales: ['es', 'en','fr'],
       current_locale: 'es',
       store: {mongodb: {}}
     }),
     _ = dialect.get,
     original = 'Hello World!',
     translation = 'Hola Mundo!';
+    translation_fr = 'Bonjour tout le monde!';
 
 dialect.connect(function () {
   console.log(_(original));
+
+  dialect.set({original: original, locale: 'fr'}, translation_fr);
+  dialect.approve({original: original, locale: 'fr'}, true);
 
   dialect.set({original: original, locale: 'es'}, translation);
   dialect.approve({original: original, locale: 'es'}, true);
 
   dialect.sync({interval: 3600}, function (err, foo) {
     console.log(_(original));
+    console.log(_(original,'fr'));
     console.log(_('Inexistant'));
+    process.exit();
   });
 });

--- a/lib/dialect.js
+++ b/lib/dialect.js
@@ -67,10 +67,11 @@ module.exports = function (options) {
    * @param {String} original
    *   String we want to translate.
    */
-  DIALECT.get = function (original) {
+  DIALECT.get = function (original,locale) {
     var translation = null,
         key = null,
-        current_dictionary = DIALECT.dictionaries[_options.current_locale],
+        current_locale = locale ? locale : _options.current_locale;
+        current_dictionary = DIALECT.dictionaries[current_locale],
         params = Array.isArray(original) ? original.pop() : {},
         needs_plural = Array.isArray(original) && original.length === 2,
         index =  Array.isArray(original) ? original[0] : original,
@@ -80,7 +81,7 @@ module.exports = function (options) {
       throw Error("Original is not valid");
     }
 
-    if (!current_dictionary || _options.base_locale === _options.current_locale) {
+    if (!current_dictionary || _options.base_locale === current_locale) {
       return _parse(needs_plural ? original[pluralize(params.count)] : index, params);
     } else {
 
@@ -96,7 +97,7 @@ module.exports = function (options) {
 
       if (typeof translation !== 'string') {
         DIALECT.store.add(
-          {original: index, locale: _options.current_locale},
+          {original: index, locale: current_locale},
           translation
         );
         return _parse(needs_plural ? original[pluralize(params.count)] : index, params);


### PR DESCRIPTION
This allows the user to select a different locale when doing a 'get'. It is useful if more than a single output locale is needed.
